### PR TITLE
Fix USDT deployment issue with safeApprove

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,8 +1,0 @@
-{
-  "lib/ajna-core": {
-    "rev": "0f59e78031af76d62ad575c18405eb325b28849f"
-  },
-  "lib/forge-std": {
-    "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
-  }
-}

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/ajna-core": {
+    "rev": "0f59e78031af76d62ad575c18405eb325b28849f"
+  },
+  "lib/forge-std": {
+    "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
+  }
+}

--- a/src/Buffer.sol
+++ b/src/Buffer.sol
@@ -39,7 +39,7 @@ contract Buffer is IBuffer {
         assetDecimals = _assetDecimals;
         vault         = msg.sender;
 
-        IERC20(quo).approve(msg.sender, type(uint256).max);
+        IERC20(quo).safeApprove(msg.sender, type(uint256).max);
     }
 
     /**

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -80,8 +80,8 @@ contract Vault is IVault, ERC4626 {
         LP_DUST = Math.max(WAD / (10**assetDecimals), 1e6 + 1);
 
         // Set up allowances for the Buffer and the pool
-        IERC20(asset()).approve(address(BUFFER), type(uint256).max);
-        IERC20(asset()).approve(address(POOL), type(uint256).max);
+        IERC20(asset()).safeApprove(address(BUFFER), type(uint256).max);
+        IERC20(asset()).safeApprove(address(POOL), type(uint256).max);
     }
 
     // EXTERNAL OVERRIDES

--- a/test/VaultUSDTDeploy.t.sol
+++ b/test/VaultUSDTDeploy.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: LicenseRef-SkyAlpha-Proprietary
+// © 2025 SkyAlpha Ventures LLC. All rights reserved. Use subject to LICENSE.txt.
+// No claims against contributors: to the maximum extent permitted by applicable law, each contributor
+// provides its contributions "AS IS", disclaims all warranties, and shall have no liability whatsoever
+// for any damages arising from or relating to the Software or its use.
+
+pragma solidity ^0.8.18;
+
+import {Test, console} from "forge-std/Test.sol";
+import {IPool} from "ajna-core/interfaces/pool/IPool.sol";
+import {PoolInfoUtils} from "ajna-core/PoolInfoUtils.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import {Vault} from "../src/Vault.sol";
+import {Buffer} from "../src/Buffer.sol";
+import {IBuffer} from "../src/interfaces/IBuffer.sol";
+import {IVault} from "../src/interfaces/IVault.sol";
+import {VaultAuth, IVaultAuth} from "../src/VaultAuth.sol";
+import {ERC4626} from "../src/ERC4626.sol";
+
+/**
+ * @title VaultUSDTDeployTest
+ * @notice Test to reproduce USDT vault deployment failure on mainnet fork
+ * @dev This test uses mainnet fork to test deployment with:
+ *      - USDT (0xdac17f958d2ee523a2206206994597c13d831ec7) as quote token
+ *      - wstETH/USDT pool (0xd7fef7e3ac0440086f6322dc47d72e6c96caa6ca) as underlying pool
+ */
+contract VaultUSDTDeployTest is Test {
+
+    // Mainnet addresses
+    address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address public constant WSTETH_USDT_POOL = 0xD7feF7E3aC0440086f6322dC47d72E6C96caA6cA;
+    address public constant AJNA_INFO = 0x30c5eF2997d6a882DE52c4ec01B6D0a5e5B4fAAE;
+
+    // Test actors
+    address public deployer = makeAddr("deployer");
+
+    // Contracts
+    Vault public vault;
+    VaultAuth public auth;
+    Buffer public buffer;
+    IPool public pool;
+    PoolInfoUtils public info;
+
+    function setUp() public {
+        // Fork mainnet at a recent block
+        string memory rpcUrl = vm.envString("ETH_RPC_URL");
+        vm.createSelectFork(rpcUrl);
+
+        console.log("=== Forked Mainnet ===");
+        console.log("Block number:", block.number);
+        console.log("Block timestamp:", block.timestamp);
+        console.log("");
+
+        pool = IPool(WSTETH_USDT_POOL);
+        info = PoolInfoUtils(AJNA_INFO);
+
+        console.log("=== Pool Information ===");
+        console.log("Pool address:", address(pool));
+        console.log("Quote token from pool:", pool.quoteTokenAddress());
+        console.log("Expected USDT address:", USDT);
+        console.log("Quote token matches USDT:", pool.quoteTokenAddress() == USDT);
+        console.log("");
+
+        console.log("=== USDT Information ===");
+        console.log("USDT decimals:", ERC20(USDT).decimals());
+        console.log("USDT name:", ERC20(USDT).name());
+        console.log("USDT symbol:", ERC20(USDT).symbol());
+        console.log("");
+    }
+
+    function test_deployVaultWithUSDT() public {
+        console.log("=== Attempting to Deploy Vault with USDT ===");
+
+        vm.startPrank(deployer);
+
+        // Deploy VaultAuth
+        console.log("Deploying VaultAuth...");
+        auth = new VaultAuth();
+        console.log("VaultAuth deployed at:", address(auth));
+        console.log("");
+
+        // Attempt to deploy Vault with USDT
+        console.log("Deploying Vault...");
+        console.log("Pool:", address(pool));
+        console.log("Info:", address(info));
+        console.log("Asset (USDT):", USDT);
+        console.log("Auth:", address(auth));
+        console.log("");
+
+        // This should fail or expose the issue
+        try this.deployVault() returns (Vault v) {
+            vault = v;
+            console.log("SUCCESS: Vault deployed at:", address(vault));
+            console.log("Vault asset:", vault.asset());
+            console.log("Vault decimals:", vault.decimals());
+            console.log("Vault assetDecimals:", vault.assetDecimals());
+            console.log("Vault buffer:", vault.buffer());
+        } catch Error(string memory reason) {
+            console.log("FAILED: Deployment reverted with reason:");
+            console.log(reason);
+            revert(reason);
+        } catch (bytes memory lowLevelData) {
+            console.log("FAILED: Deployment reverted with low-level error");
+            console.logBytes(lowLevelData);
+            revert("Deployment failed with low-level error");
+        }
+
+        vm.stopPrank();
+    }
+
+    // External function to enable try/catch
+    function deployVault() external returns (Vault) {
+        return new Vault(
+            pool,
+            address(info),
+            IERC20(USDT),
+            "USDT Vault",
+            "vUSDT",
+            IVaultAuth(address(auth))
+        );
+    }
+
+    function test_verifyPoolQuoteToken() public view {
+        console.log("=== Verifying Pool Quote Token ===");
+        address quoteToken = pool.quoteTokenAddress();
+        console.log("Quote token from pool:", quoteToken);
+        console.log("USDT address:", USDT);
+
+        assertEq(quoteToken, USDT, "Pool quote token should be USDT");
+    }
+
+    function test_verifyUSDTDecimals() public view {
+        console.log("=== Verifying USDT Decimals ===");
+        uint8 decimals = ERC20(USDT).decimals();
+        console.log("USDT decimals:", decimals);
+
+        assertEq(decimals, 6, "USDT should have 6 decimals");
+        assertTrue(decimals > 0 && decimals <= 18, "USDT decimals should be valid for vault");
+    }
+}

--- a/test/VaultUSDTDeploy.t.sol
+++ b/test/VaultUSDTDeploy.t.sol
@@ -121,22 +121,4 @@ contract VaultUSDTDeployTest is Test {
             IVaultAuth(address(auth))
         );
     }
-
-    function test_verifyPoolQuoteToken() public view {
-        console.log("=== Verifying Pool Quote Token ===");
-        address quoteToken = pool.quoteTokenAddress();
-        console.log("Quote token from pool:", quoteToken);
-        console.log("USDT address:", USDT);
-
-        assertEq(quoteToken, USDT, "Pool quote token should be USDT");
-    }
-
-    function test_verifyUSDTDecimals() public view {
-        console.log("=== Verifying USDT Decimals ===");
-        uint8 decimals = ERC20(USDT).decimals();
-        console.log("USDT decimals:", decimals);
-
-        assertEq(decimals, 6, "USDT should have 6 decimals");
-        assertTrue(decimals > 0 && decimals <= 18, "USDT decimals should be valid for vault");
-    }
 }

--- a/test/VaultUSDTDeploy.t.sol
+++ b/test/VaultUSDTDeploy.t.sol
@@ -7,17 +7,8 @@
 pragma solidity ^0.8.18;
 
 import {Test, console} from "forge-std/Test.sol";
-import {IPool} from "ajna-core/interfaces/pool/IPool.sol";
-import {PoolInfoUtils} from "ajna-core/PoolInfoUtils.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import {Vault} from "../src/Vault.sol";
-import {Buffer} from "../src/Buffer.sol";
-import {IBuffer} from "../src/interfaces/IBuffer.sol";
-import {IVault} from "../src/interfaces/IVault.sol";
-import {VaultAuth, IVaultAuth} from "../src/VaultAuth.sol";
-import {ERC4626} from "../src/ERC4626.sol";
+import "./Vault.base.t.sol";
 
 /**
  * @title VaultUSDTDeployTest
@@ -26,77 +17,38 @@ import {ERC4626} from "../src/ERC4626.sol";
  *      - USDT (0xdac17f958d2ee523a2206206994597c13d831ec7) as quote token
  *      - wstETH/USDT pool (0xd7fef7e3ac0440086f6322dc47d72e6c96caa6ca) as underlying pool
  */
-contract VaultUSDTDeployTest is Test {
+contract VaultUSDTDeployTest is VaultBaseTest {
 
     // Mainnet addresses
     address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
     address public constant WSTETH_USDT_POOL = 0xD7feF7E3aC0440086f6322dC47d72E6C96caA6cA;
-    address public constant AJNA_INFO = 0x30c5eF2997d6a882DE52c4ec01B6D0a5e5B4fAAE;
 
     // Test actors
     address public deployer = makeAddr("deployer");
 
-    // Contracts
-    Vault public vault;
-    VaultAuth public auth;
-    Buffer public buffer;
-    IPool public pool;
-    PoolInfoUtils public info;
+    function setUp() public override {
+        // Create fork at specific block for USDT pool
+        try vm.envString("ETH_RPC_URL") returns (string memory rpcUrl) {
+            vm.createSelectFork(rpcUrl, 23955000);
+            liveFork = true;
 
-    function setUp() public {
-        // Fork mainnet at a recent block
-        string memory rpcUrl = vm.envString("ETH_RPC_URL");
-        vm.createSelectFork(rpcUrl);
-
-        console.log("=== Forked Mainnet ===");
-        console.log("Block number:", block.number);
-        console.log("Block timestamp:", block.timestamp);
-        console.log("");
-
-        pool = IPool(WSTETH_USDT_POOL);
-        info = PoolInfoUtils(AJNA_INFO);
-
-        console.log("=== Pool Information ===");
-        console.log("Pool address:", address(pool));
-        console.log("Quote token from pool:", pool.quoteTokenAddress());
-        console.log("Expected USDT address:", USDT);
-        console.log("Quote token matches USDT:", pool.quoteTokenAddress() == USDT);
-        console.log("");
-
-        console.log("=== USDT Information ===");
-        console.log("USDT decimals:", ERC20(USDT).decimals());
-        console.log("USDT name:", ERC20(USDT).name());
-        console.log("USDT symbol:", ERC20(USDT).symbol());
-        console.log("");
+            pool = IPool(WSTETH_USDT_POOL);
+            info = PoolInfoUtils(AJNA_INFO);
+        } catch {
+            liveFork = false;
+        }
     }
 
-    function test_deployVaultWithUSDT() public {
-        console.log("=== Attempting to Deploy Vault with USDT ===");
+    function test_deployVaultWithUSDT() public onlyLiveFork {
 
         vm.startPrank(deployer);
 
         // Deploy VaultAuth
-        console.log("Deploying VaultAuth...");
         auth = new VaultAuth();
-        console.log("VaultAuth deployed at:", address(auth));
-        console.log("");
-
-        // Attempt to deploy Vault with USDT
-        console.log("Deploying Vault...");
-        console.log("Pool:", address(pool));
-        console.log("Info:", address(info));
-        console.log("Asset (USDT):", USDT);
-        console.log("Auth:", address(auth));
-        console.log("");
 
         // This should fail or expose the issue
         try this.deployVault() returns (Vault v) {
             vault = v;
-            console.log("SUCCESS: Vault deployed at:", address(vault));
-            console.log("Vault asset:", vault.asset());
-            console.log("Vault decimals:", vault.decimals());
-            console.log("Vault assetDecimals:", vault.assetDecimals());
-            console.log("Vault buffer:", vault.buffer());
         } catch Error(string memory reason) {
             console.log("FAILED: Deployment reverted with reason:");
             console.log(reason);


### PR DESCRIPTION
  # Fix USDT Vault Deployment Issue

  Found and fixed an issue that was preventing vault deployment when using USDT (or other non-standard ERC20 tokens) as the quote token.

  ## The Problem

  When attempting to deploy a vault with USDT as the quote token, the deployment would fail during the constructor. The issue stems from USDT's non-standard ERC20 implementation - specifically, its `approve()` function doesn't return a boolean value like the standard ERC20 spec requires.

  When Solidity calls `IERC20.approve()` directly, it expects a boolean return value. USDT returns nothing, causing the transaction to revert.

  ## The Fix

  We were already importing and using SafeERC20 throughout the codebase, but there were three spots where we were calling `approve()` directly instead
   of using the safe wrapper:

  ### Changed Files:

  **src/Vault.sol** (lines 83-84)
  ```diff
  - IERC20(asset()).approve(address(BUFFER), type(uint256).max);
  - IERC20(asset()).approve(address(POOL), type(uint256).max);
  + IERC20(asset()).safeApprove(address(BUFFER), type(uint256).max);
  + IERC20(asset()).safeApprove(address(POOL), type(uint256).max);
```

  src/Buffer.sol (line 42)
```diff
  - IERC20(quo).approve(msg.sender, type(uint256).max);
  + IERC20(quo).safeApprove(msg.sender, type(uint256).max);
```

  Why This Works

  SafeERC20's safeApprove() uses low-level calls that handle tokens with non-standard return values. It works with both:
  - Standard ERC20 tokens (that return bool)
  - Non-standard tokens like USDT (that return nothing)

  The rest of the codebase was already using safeTransfer() and safeTransferFrom() correctly - these were the only three instances that needed fixing.

  Testing

  Created a new test file test/VaultUSDTDeploy.t.sol that:
  - Forks mainnet
  - Attempts to deploy a vault with USDT (0xdAC17F958D2ee523a2206206994597C13D831ec7) as the quote token
  - Uses the wstETH/USDT pool (0xd7fEF7E3Ac0440086f6322Dc47d72E6c96CAA6cA)
  - Verifies successful deployment

  The test can be run with:
  forge test --match-contract VaultUSDTDeployTest --match-test test_deployVaultWithUSDT -vvv

  Impact

  This is a critical fix for mainnet deployment. Without it, any vault using USDT (or similar tokens like USDC in some versions) would fail to deploy.
   With this fix, the vault now supports the full range of ERC20 tokens including non-standard implementations.

  ---
  Let me know if you have any questions or want me to adjust anything!
